### PR TITLE
Give credit where credit is due

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ export interface IActiveBackgroundPattern {
   stop(): void
 }
 ```
+
+## Authors
+
+This library was originally created by @neenjaw. It is maintained by @neenjaw, @sleeplessbyte and the Exercism team. See the [GitHub contributors graph](https://github.com/exercism/react-active-background/graphs/contributors) for a full list of contributors.


### PR DESCRIPTION
For libraries that we're bringing into the Exercism org but where there's been a central creator, I'd like to add an authors section ensuring the original creator is properly credited, and also that they don't implicitly end up with later work attributed to them that they may not want attributed to them. I've tried to word this to meet those requirements but entirely open to suggestions/rewording. Extra emojis also welcome!

(cc @angelikatyborska to add something similar to your work).
(I'm presuming @SleeplessByte is helping here on a moving-forward basis, but if that assumption is wrong, then feel free to delete your name etc!)